### PR TITLE
fix: Serenity バージョンを下げる

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serenity = {version = "0.12.0", features = ["framework", "standard_framework"] }
+serenity = {version = "0.11.7", features = ["framework", "standard_framework"] }
 tokio = {version = "1.33.0", features = ["full"] }
 dotenv = "0.15.0"
 anyhow = "1.0.75"


### PR DESCRIPTION
Dockerのバージョンに対応していないらしい